### PR TITLE
Add data labels to mean and process limits on the visual

### DIFF
--- a/src/Classes/plotPropertiesClass.ts
+++ b/src/Classes/plotPropertiesClass.ts
@@ -29,6 +29,10 @@ export default class plotPropertiesClass {
   yAxis: axisProperties;
   xScale: d3.ScaleLinear<number, number, never>;
   yScale: d3.ScaleLinear<number, number, never>;
+  dataLabels: {
+    mean: { x: number, y: number, value: number }[],
+    processLimits: { x: number, y: number, value: number }[]
+  };
 
   // Separate function so that the axis can be re-calculated on changes to padding
   initialiseScale(svgWidth: number, svgHeight: number): void {
@@ -149,5 +153,19 @@ export default class plotPropertiesClass {
     };
 
     this.initialiseScale(options.viewport.width, options.viewport.height);
+
+    // Update data labels for mean and process limits
+    this.dataLabels = {
+      mean: controlLimits.keys.map((d, i) => ({
+        x: this.xScale(d.x) + 5,
+        y: this.yScale(controlLimits.values[i]),
+        value: controlLimits.values[i]
+      })),
+      processLimits: controlLimits.keys.map((d, i) => ({
+        x: this.xScale(d.x) + 5,
+        y: this.yScale(controlLimits.ul99[i]),
+        value: controlLimits.ul99[i]
+      }))
+    };
   }
 }

--- a/src/D3 Plotting Functions/drawLines.ts
+++ b/src/D3 Plotting Functions/drawLines.ts
@@ -31,4 +31,28 @@ export default function drawLines(selection: svgBaseType, visualObj: Visual) {
       })
       .attr("stroke-width", d => getAesthetic(d[0], "lines", "width", visualObj.viewModel.inputSettings.settings))
       .attr("stroke-dasharray", d => getAesthetic(d[0], "lines", "type", visualObj.viewModel.inputSettings.settings));
+
+  // Add data labels for mean and process limits
+  const dataLabels = visualObj.viewModel.plotProperties.dataLabels;
+  selection
+      .select(".linesgroup")
+      .selectAll("text.mean-label")
+      .data(dataLabels.mean)
+      .join("text")
+      .attr("class", "mean-label")
+      .attr("x", d => d.x)
+      .attr("y", d => d.y)
+      .attr("dx", 5)
+      .text(d => d.value.toFixed(2));
+
+  selection
+      .select(".linesgroup")
+      .selectAll("text.process-limit-label")
+      .data(dataLabels.processLimits)
+      .join("text")
+      .attr("class", "process-limit-label")
+      .attr("x", d => d.x)
+      .attr("y", d => d.y)
+      .attr("dx", 5)
+      .text(d => d.value.toFixed(2));
 }

--- a/src/D3 Plotting Functions/drawTooltipLine.ts
+++ b/src/D3 Plotting Functions/drawTooltipLine.ts
@@ -56,4 +56,28 @@ export default function drawTooltipLine(selection: svgBaseType, visualObj: Visua
     xAxisLine.style("stroke-opacity", 0);
     yAxisLine.style("stroke-opacity", 0);
   });
+
+  // Add data labels for mean and process limits
+  const dataLabels = visualObj.viewModel.plotProperties.dataLabels;
+  selection
+      .select(".linesgroup")
+      .selectAll("text.mean-label")
+      .data(dataLabels.mean)
+      .join("text")
+      .attr("class", "mean-label")
+      .attr("x", d => d.x)
+      .attr("y", d => d.y)
+      .attr("dx", 5)
+      .text(d => d.value.toFixed(2));
+
+  selection
+      .select(".linesgroup")
+      .selectAll("text.process-limit-label")
+      .data(dataLabels.processLimits)
+      .join("text")
+      .attr("class", "process-limit-label")
+      .attr("x", d => d.x)
+      .attr("y", d => d.y)
+      .attr("dx", 5)
+      .text(d => d.value.toFixed(2));
 }


### PR DESCRIPTION
Add data labels to mean and process limits on the visual.

* Add properties for data labels for mean and process limits in `src/Classes/plotPropertiesClass.ts`
* Update `update` method in `src/Classes/plotPropertiesClass.ts` to include data labels for mean and process limits
* Add functionality to draw data labels for mean and process limits in `src/D3 Plotting Functions/drawLines.ts`
* Position data labels to the right of the graph with 5 pixels of space between the line end and the data label in `src/D3 Plotting Functions/drawLines.ts`
* Add functionality to display data labels for mean and process limits in `src/D3 Plotting Functions/drawTooltipLine.ts`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shauneccles/PowerBI-SPC?shareId=XXXX-XXXX-XXXX-XXXX).